### PR TITLE
New: Add new props for polyglot options

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ npm install --save react-polyglot
 
 ## Usage
 
-`react-polyglot` exports consists for one wrapper component called `I18n` and one decorator called
-`translate`. The decorator provides a prop `t` which is instance of `Polyglot`.
+`react-polyglot` exports consists for one wrapper component called `I18n`, one decorator called
+`translate` and one hook called `useTranslate`. The decorator provides a prop `t` which is instance of `Polyglot`.
 
 You are required to wrap your root component with `I18n` and pass on a `locale` like `en` or `fr`.
 And `messages` object containing the strings.
@@ -58,6 +58,28 @@ Greeter.propTypes = {
 
 export default translate()(Greeter);
 ```
+
+
+or with React Hooks:
+
+```js
+import React from 'react';
+import { useTranslate } from 'react-polyglot';
+
+export default const Greeter = ({ name }) => {
+  const t = useTranslate();
+
+  return (
+    <h3>{t('hello_name', { name })}</h3>
+  );
+};
+
+Greeter.propTypes = {
+  name: React.PropTypes.string.isRequired
+};
+
+```
+
 
 ## Live Examples
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-polyglot",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Higher order React component for using Polyglot",
   "main": "lib/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-polyglot",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "Higher order React component for using Polyglot",
   "main": "lib/index.js",
   "files": [

--- a/src/i18n.d.ts
+++ b/src/i18n.d.ts
@@ -3,12 +3,44 @@
 
 import { ComponentType, ReactNode } from 'react'
 
-interface I18nProps {
-  children: ReactNode
+interface InterpolationOptions {
+    smart_count?: number | { length: number };
+    _?: string;
+    [interpolationKey: string]: any;
+}
+
+interface InterpolationTokenOptions {
+  prefix?: string;
+  suffix?: string;
+}
+
+interface PluralRules {
+    pluralTypes: {
+        [key: string]: (no: number) => number;
+    };
+    pluralTypeToLanguages: {
+        [key: string]: string[];
+    };
+}
+
+interface PolyglotOptions {
   /** Locale to use, e.g. `en` */
-  locale: number
+  locale: string;
   /** A dictionary of translations */
-  messages: object
+  messages: object;
+
+  /** A boolean to control whether missing keys are allowed **/
+  allowMissing?: boolean;
+  /** If allow missing is true this function will be called instead of default error handler **/
+  onMissingKey?: (key: string, options?: InterpolationOptions, locale?: string) => string;
+  /** An object to change the substituation syntax for interpolation by setting prefix and suffix **/
+  interpolation?: InterpolationTokenOptions;
+  /** https://github.com/airbnb/polyglot.js#custom-pluralization-rules */
+  pluralRules?: PluralRules;
+}
+
+interface I18nProps extends PolyglotOptions {
+  children: ReactNode;
 }
 
 /** Provider component to wrap your root application component in. */

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -11,16 +11,21 @@ export default class I18n extends React.Component {
     this._polyglot = new Polyglot({
       locale: props.locale,
       phrases: props.messages,
+
+      allowMissing: props.allowMissing,
+      onMissingKey: props.onMissingKey,
+      interpolation: props.interpolation,
+      pluralRules: props.pluralRules,
     })
   }
 
-  componentWillReceiveProps(newProps) {
-    if (newProps.locale !== this.props.locale) {
-      this._polyglot.locale(newProps.locale)
+  componentDidUpdate(prevProps) {
+    if (prevProps.locale !== this.props.locale) {
+      this._polyglot.locale(this.props.locale)
     }
 
-    if (newProps.messages !== this.props.messages) {
-      this._polyglot.replace(newProps.messages)
+    if (prevProps.messages !== this.props.messages) {
+      this._polyglot.replace(this.props.messages)
     }
   }
 
@@ -38,5 +43,24 @@ export default class I18n extends React.Component {
 I18n.propTypes = {
   locale: PropTypes.string.isRequired,
   messages: PropTypes.object.isRequired,
+
+  allowMissing: PropTypes.bool,
+  onMissingKey: PropTypes.func,
+  interpolation: PropTypes.shape({
+    suffix: PropTypes.string,
+    prefix: PropTypes.string,
+  }),
+  pluralRules: PropTypes.shape({
+    pluralTypes: PropTypes.object,
+    pluralTypeToLanguages: PropTypes.object,
+  }),
+
   children: PropTypes.element.isRequired,
+}
+
+I18n.defaultProps = {
+  allowMissing: false,
+  onMissingKey: undefined,
+  interpolation: undefined,
+  pluralRules: undefined,
 }

--- a/src/i18n.test.js
+++ b/src/i18n.test.js
@@ -30,12 +30,18 @@ describe('I18n Provider', () => {
 
     const instance = renderer.root.instance
 
-    instance.componentWillReceiveProps({
+    const newProps = {
       locale: 'jp',
       messages: {
-        test: 'Testo',
+        test: 'test',
       },
-    })
+    }
+
+    renderer.update(
+      <I18n {...newProps}>
+        <Child />
+      </I18n>
+    )
 
     expect(instance._polyglot.locale()).toBe('jp')
   })

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,3 +1,4 @@
 export { default as I18n } from './i18n';
 export { default as translate } from './translate';
+export { default as useTranslate} from './useTranslate';
 export * from './translate';

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import I18n from './i18n'
 import translate from './translate'
+import useTranslate from './useTranslate'
 
-export { I18n, translate }
+export { I18n, translate, useTranslate }

--- a/src/useTranslate.d.ts
+++ b/src/useTranslate.d.ts
@@ -1,0 +1,10 @@
+import { InterpolationOptions } from 'node-polyglot'
+
+type TranslateFunction = (
+    phrase: string,
+    options?: number| InterpolationOptions
+) => string
+
+declare const useTranslate = () => TranslateFunction
+
+export default useTranslate

--- a/src/useTranslate.js
+++ b/src/useTranslate.js
@@ -1,0 +1,6 @@
+import { useContext } from 'react'
+import I18nContext from './i18n-context'
+
+export default function useTranslate() {
+  return useContext(I18nContext)
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3136,8 +3136,8 @@ minizlib@^1.1.0:
     minipass "^2.2.1"
 
 mixin-deep@^1.2.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.1.tgz#a49e7268dce1a0d9698e45326c5626df3543d0fe"
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.2.tgz#1120b43dc359a785dce65b55b82e257ccf479566"
   dependencies:
     for-in "^1.0.2"
     is-extendable "^1.0.1"


### PR DESCRIPTION
 This commits adds new props for the following polylgot options:
   - allowMissing
   - onMissingKey
   - interpolation

 It also removes the use of componentWillReceiveProps() since it has
 been deprecated and replaces it with componentDidUpdate().